### PR TITLE
Fix spacing typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 # Login 화면
 <img width="330" alt="login" src="https://github.com/user-attachments/assets/2c85b0ba-6f86-495e-bf3f-54444905a40a" /><br>
 로그인 과정을 담당하는 LoginBloc과 사용자 정보를 담당하는 UserBloc간 의존성 관계가 생기지 않도록<br>
-각 Bloc의 BlocListener를 MultiBlocListener 안에 배치하여 Login Event가 성공했을때, UserEvent를 발생시키도록 한다.
+각 Bloc의 BlocListener를 MultiBlocListener 안에 배치하여 Login Event가 성공했을 때, UserEvent를 발생시키도록 한다.
 <br>
 
 ``` dart


### PR DESCRIPTION
## Summary
- fix a Korean spacing typo in the login Bloc section of the README

## Testing
- `grep -n "성공했을 때" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68764e8446448325814a107c62d9804f