### PR TITLE
Fix repository instance mismatch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,7 @@ class MainApp extends StatelessWidget {
         ),
         RepositoryProvider(
           lazy: false,
-          create: (_) => UserRepository(locator<FirestoreDataSource>()),
+          create: (_) => locator<UserRepository>(),
         ),
       ],
 


### PR DESCRIPTION
## Summary
- use the shared `UserRepository` singleton when providing the repository

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764b3e182c832593d282396619e885