### PR TITLE
test: add widget tests for presentation layer

### DIFF
--- a/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
+++ b/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
@@ -1,9 +1,18 @@
+import 'dart:typed_data';
+
 import 'package:door_stamp/presentation/features/daily_box_office/data/models/daily_box_office_model.dart';
 import 'package:door_stamp/presentation/features/daily_box_office/presentation/widget/daily_rank_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (_) async => ByteData(0));
+  });
+
   final movies = [
     DailyBoxOfficeMovieModel(
       movieCd: '1',

--- a/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
+++ b/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:door_stamp/presentation/features/daily_box_office/data/models/daily_box_office_model.dart';
@@ -9,8 +10,17 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (_) async => ByteData(0));
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decoder.convert(message!.buffer.asUint8List());
+      if (key.endsWith('.svg')) {
+        final bytes = Uint8List.fromList(
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>'.codeUnits);
+        return bytes.buffer.asByteData();
+      }
+      return ByteData(0);
+    });
   });
 
   final movies = [

--- a/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
+++ b/test/daily_box_office/presentation/widget/daily_rank_widget_test.dart
@@ -1,0 +1,55 @@
+import 'package:door_stamp/presentation/features/daily_box_office/data/models/daily_box_office_model.dart';
+import 'package:door_stamp/presentation/features/daily_box_office/presentation/widget/daily_rank_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final movies = [
+    DailyBoxOfficeMovieModel(
+      movieCd: '1',
+      movieNm: 'Movie 1',
+      openDt: '2024-01-01',
+      audiCnt: '100',
+    ),
+    DailyBoxOfficeMovieModel(
+      movieCd: '2',
+      movieNm: 'Movie 2',
+      openDt: '2024-01-02',
+      audiCnt: '200',
+    ),
+    DailyBoxOfficeMovieModel(
+      movieCd: '3',
+      movieNm: 'Movie 3',
+      openDt: '2024-01-03',
+      audiCnt: '300',
+    ),
+    DailyBoxOfficeMovieModel(
+      movieCd: '4',
+      movieNm: 'Movie 4',
+      openDt: '2024-01-04',
+      audiCnt: '400',
+    ),
+  ];
+
+  testWidgets('renders movie titles and handles tap', (tester) async {
+    String? selectedId;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DailyRankWidget(
+          dailyBoxOfficeMovieList: movies,
+          onMovieSelected: (movieCd) {
+            selectedId = movieCd;
+          },
+        ),
+      ),
+    );
+
+    for (final movie in movies) {
+      expect(find.text(movie.movieNm ?? ''), findsOneWidget);
+    }
+
+    await tester.tap(find.byKey(const ValueKey('1')));
+    await tester.pumpAndSettle();
+    expect(selectedId, '1');
+  });
+}

--- a/test/login/widget/login_form_test.dart
+++ b/test/login/widget/login_form_test.dart
@@ -1,26 +1,23 @@
+import 'dart:typed_data';
+
 import 'package:door_stamp/common/bloc/user/user_bloc.dart';
 import 'package:door_stamp/presentation/screens/login/bloc/login_bloc.dart';
 import 'package:door_stamp/presentation/screens/login/widget/login_form.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/services.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class MockLoginBloc extends MockBloc<LoginEvent, LoginState> implements LoginBloc {}
 class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
 
-class FakeLoginEvent extends Fake implements LoginEvent {}
-class FakeUserEvent extends Fake implements UserEvent {}
-class FakeLoginState extends Fake implements LoginState {}
-class FakeUserState extends Fake implements UserState {}
-
 void main() {
-  setUpAll(() {
-    registerFallbackValue(FakeLoginEvent());
-    registerFallbackValue(FakeUserEvent());
-    registerFallbackValue(const LoginState());
-    registerFallbackValue(const UserInitial());
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (_) async => ByteData(0));
   });
 
   testWidgets('shows login buttons for all SSO types', (tester) async {

--- a/test/login/widget/login_form_test.dart
+++ b/test/login/widget/login_form_test.dart
@@ -1,0 +1,48 @@
+import 'package:door_stamp/common/bloc/user/user_bloc.dart';
+import 'package:door_stamp/presentation/screens/login/bloc/login_bloc.dart';
+import 'package:door_stamp/presentation/screens/login/widget/login_form.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MockLoginBloc extends MockBloc<LoginEvent, LoginState> implements LoginBloc {}
+class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
+
+class FakeLoginEvent extends Fake implements LoginEvent {}
+class FakeUserEvent extends Fake implements UserEvent {}
+class FakeLoginState extends Fake implements LoginState {}
+class FakeUserState extends Fake implements UserState {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeLoginEvent());
+    registerFallbackValue(FakeUserEvent());
+    registerFallbackValue(const LoginState());
+    registerFallbackValue(const UserInitial());
+  });
+
+  testWidgets('shows login buttons for all SSO types', (tester) async {
+    final loginBloc = MockLoginBloc();
+    final userBloc = MockUserBloc();
+    when(() => loginBloc.state).thenReturn(const LoginState());
+    when(() => userBloc.state).thenReturn(const UserInitial());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<LoginBloc>.value(value: loginBloc),
+            BlocProvider<UserBloc>.value(value: userBloc),
+          ],
+          child: const LoginForm(),
+        ),
+      ),
+    );
+
+    for (final type in SSOType.values) {
+      expect(find.text(type.loginText), findsOneWidget);
+    }
+  });
+}

--- a/test/login/widget/login_form_test.dart
+++ b/test/login/widget/login_form_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:door_stamp/common/bloc/user/user_bloc.dart';
@@ -16,8 +17,17 @@ class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
 void main() {
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (_) async => ByteData(0));
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decoder.convert(message!.buffer.asUint8List());
+      if (key.endsWith('.svg')) {
+        final bytes = Uint8List.fromList(
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>'.codeUnits);
+        return bytes.buffer.asByteData();
+      }
+      return ByteData(0);
+    });
   });
 
   testWidgets('shows login buttons for all SSO types', (tester) async {
@@ -37,6 +47,8 @@ void main() {
         ),
       ),
     );
+
+    await tester.pumpAndSettle();
 
     for (final type in SSOType.values) {
       expect(find.text(type.loginText), findsOneWidget);

--- a/test/movie_detail/widget/movie_default_info_test.dart
+++ b/test/movie_detail/widget/movie_default_info_test.dart
@@ -1,0 +1,49 @@
+import 'package:door_stamp/presentation/screens/movie_detail/data/models/movie_detail_model.dart';
+import 'package:door_stamp/presentation/screens/movie_detail/presentation/widget/movie_default_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final info = MovieDetailInfoModel(
+    movieCd: '001',
+    movieNm: 'Test Movie',
+    movieNmEn: 'Test Movie',
+    movieNmOg: 'Test Movie',
+    showTm: '123',
+    prdtYear: '2024',
+    openDt: '2024-01-01',
+    prdtStatNm: '',
+    typeNm: '',
+    nations: const [],
+    genres: const [],
+    directors: const [],
+    actors: const [],
+    showTypes: const [],
+    companys: const [
+      CompanyModel(
+        companyCd: 'C1',
+        companyNm: 'Company',
+        companyNmEn: 'Company',
+        companyPartNm: 'Producer',
+      ),
+    ],
+    audits: const [],
+    staffs: const [],
+  );
+
+  testWidgets('displays basic movie info rows', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MovieDefaultInfo(
+          movieDetailInfo: info,
+          prevDayTotalAudits: 1000,
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('movie_default_info_release_date')), findsOneWidget);
+    expect(find.byKey(const Key('movie_default_info_total_audits')), findsOneWidget);
+    expect(find.byKey(const Key('movie_default_info_running_time')), findsOneWidget);
+    expect(find.byKey(const Key('movie_default_info_companys')), findsOneWidget);
+  });
+}

--- a/test/movie_detail/widget/movie_default_info_test.dart
+++ b/test/movie_detail/widget/movie_default_info_test.dart
@@ -19,7 +19,7 @@ void main() {
     directors: const [],
     actors: const [],
     showTypes: const [],
-    companys: const [
+    companys: [
       CompanyModel(
         companyCd: 'C1',
         companyNm: 'Company',

--- a/test/on_board/widget/genre_card_test.dart
+++ b/test/on_board/widget/genre_card_test.dart
@@ -1,0 +1,24 @@
+import 'package:door_stamp/presentation/screens/on_board/data/models/favorite_genre_model.dart';
+import 'package:door_stamp/presentation/screens/on_board/presentation/widget/genre_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows genre text and reacts to tap', (tester) async {
+    FavoriteGenre? tapped;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GenreCard(
+          genre: FavoriteGenre.action,
+          isSelected: false,
+          onTap: (genre) => tapped = genre,
+        ),
+      ),
+    );
+
+    expect(find.text(FavoriteGenre.action.korean), findsOneWidget);
+    await tester.tap(find.byKey(Key(FavoriteGenre.action.korean)));
+    await tester.pumpAndSettle();
+    expect(tapped, FavoriteGenre.action);
+  });
+}

--- a/test/search/presentation/widget/search_view_test.dart
+++ b/test/search/presentation/widget/search_view_test.dart
@@ -1,0 +1,47 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:door_stamp/presentation/screens/search/data/models/movie_model.dart';
+import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_search_bloc.dart';
+import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_search_event.dart';
+import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_search_state.dart';
+import 'package:door_stamp/presentation/screens/search/presentation/widget/search_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockMovieSearchBloc extends MockBloc<MovieSearchEvent, MovieSearchState>
+    implements MovieSearchBloc {}
+
+class FakeMovieSearchEvent extends Fake implements MovieSearchEvent {}
+class FakeMovieSearchState extends Fake implements MovieSearchState {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMovieSearchEvent());
+    registerFallbackValue(const MovieSearchState());
+  });
+
+  testWidgets('renders movie list when search succeeds', (tester) async {
+    final bloc = MockMovieSearchBloc();
+    final movies = [
+      MovieModel(id: '1', title: 'A'),
+      MovieModel(id: '2', title: 'B'),
+    ];
+    when(() => bloc.state).thenReturn(
+      MovieSearchState(status: MovieSearchStatus.success, movies: movies),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider<MovieSearchBloc>.value(
+          value: bloc,
+          child: const SearchView(),
+        ),
+      ),
+    );
+
+    expect(find.byType(ListTile), findsNWidgets(movies.length));
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
+  });
+}

--- a/test/search/presentation/widget/search_view_test.dart
+++ b/test/search/presentation/widget/search_view_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:door_stamp/presentation/screens/search/data/models/movie_model.dart';
 import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_search_bloc.dart';
@@ -5,6 +8,7 @@ import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_s
 import 'package:door_stamp/presentation/screens/search/presentation/bloc/movie_search_state.dart';
 import 'package:door_stamp/presentation/screens/search/presentation/widget/search_view.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,15 +17,31 @@ class MockMovieSearchBloc extends MockBloc<MovieSearchEvent, MovieSearchState>
     implements MovieSearchBloc {}
 
 void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decoder.convert(message!.buffer.asUint8List());
+      if (key.endsWith('.svg')) {
+        final bytes = Uint8List.fromList(
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>'.codeUnits);
+        return bytes.buffer.asByteData();
+      }
+      return ByteData(0);
+    });
+  });
+
   testWidgets('renders movie list when search succeeds', (tester) async {
     final bloc = MockMovieSearchBloc();
     final movies = [
       MovieModel(id: '1', title: 'A'),
       MovieModel(id: '2', title: 'B'),
     ];
-    when(() => bloc.state).thenReturn(
-      MovieSearchState(status: MovieSearchStatus.success, movies: movies),
-    );
+    final state =
+        MovieSearchState(status: MovieSearchStatus.success, movies: movies);
+    when(() => bloc.state).thenReturn(state);
+    whenListen(bloc, Stream<MovieSearchState>.fromIterable([state]));
 
     await tester.pumpWidget(
       MaterialApp(
@@ -31,6 +51,8 @@ void main() {
         ),
       ),
     );
+
+    await tester.pumpAndSettle();
 
     expect(find.byType(ListTile), findsNWidgets(movies.length));
     expect(find.text('A'), findsOneWidget);

--- a/test/search/presentation/widget/search_view_test.dart
+++ b/test/search/presentation/widget/search_view_test.dart
@@ -12,15 +12,7 @@ import 'package:mocktail/mocktail.dart';
 class MockMovieSearchBloc extends MockBloc<MovieSearchEvent, MovieSearchState>
     implements MovieSearchBloc {}
 
-class FakeMovieSearchEvent extends Fake implements MovieSearchEvent {}
-class FakeMovieSearchState extends Fake implements MovieSearchState {}
-
 void main() {
-  setUpAll(() {
-    registerFallbackValue(FakeMovieSearchEvent());
-    registerFallbackValue(const MovieSearchState());
-  });
-
   testWidgets('renders movie list when search succeeds', (tester) async {
     final bloc = MockMovieSearchBloc();
     final movies = [


### PR DESCRIPTION
## Summary
- add widget test for daily box office ranking widget
- add widget test verifying SSO buttons in login form
- add widget tests for movie info, onboarding genre card, and search view

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689408e870208325bc5a864e17e4b58e